### PR TITLE
Use multi-threaded scan nodes with mt_dop > 0

### DIFF
--- a/be/src/exec/hdfs-scan-node-base.h
+++ b/be/src/exec/hdfs-scan-node-base.h
@@ -740,6 +740,9 @@ class HdfsScanNodeBase : public ScanNode {
   AtomicInt32 num_scanners_codegen_enabled_;
   AtomicInt32 num_scanners_codegen_disabled_;
 
+  /// The number of scan ranges that need to be scanned by a non-MT scan node.
+  AtomicInt32 num_scan_ranges_;
+
   /// If true, counters are actively running and need to be reported in the runtime
   /// profile.
   bool counters_running_ = false;

--- a/be/src/exec/scan-node.cc
+++ b/be/src/exec/scan-node.cc
@@ -132,7 +132,8 @@ Status ScanPlanNode::CreateExecNode(RuntimeState* state, ExecNode** node) const 
         *node = pool->Add(new KuduScanNodeMt(pool, *this, state->desc_tbl()));
       } else {
         DCHECK(state->query_options().mt_dop == 0
-            || state->query_options().num_scanner_threads == 1);
+            || state->query_options().num_scanner_threads == 1
+            || state->query_options().disable_scan_node_mt);
         *node = pool->Add(new KuduScanNode(pool, *this, state->desc_tbl()));
       }
       break;

--- a/be/src/service/query-options.cc
+++ b/be/src/service/query-options.cc
@@ -1220,6 +1220,10 @@ Status impala::SetQueryOption(const string& key, const string& value,
         query_options->__set_test_replan(IsTrue(value));
         break;
       }
+      case TImpalaQueryOptions::DISABLE_SCAN_NODE_MT: {
+        query_options->__set_disable_scan_node_mt(IsTrue(value));
+        break;
+      }
       default:
         if (IsRemovedQueryOption(key)) {
           LOG(WARNING) << "Ignoring attempt to set removed query option '" << key << "'";

--- a/be/src/service/query-options.h
+++ b/be/src/service/query-options.h
@@ -50,7 +50,7 @@ typedef std::unordered_map<string, beeswax::TQueryOptionLevel::type>
 // time we add or remove a query option to/from the enum TImpalaQueryOptions.
 #define QUERY_OPTS_TABLE\
   DCHECK_EQ(_TImpalaQueryOptions_VALUES_TO_NAMES.size(),\
-      TImpalaQueryOptions::LOCK_MAX_WAIT_TIME_S + 1);\
+      TImpalaQueryOptions::DISABLE_SCAN_NODE_MT + 1);\
   REMOVED_QUERY_OPT_FN(abort_on_default_limit_exceeded, ABORT_ON_DEFAULT_LIMIT_EXCEEDED)\
   QUERY_OPT_FN(abort_on_error, ABORT_ON_ERROR, TQueryOptionLevel::REGULAR)\
   REMOVED_QUERY_OPT_FN(allow_unsupported_formats, ALLOW_UNSUPPORTED_FORMATS)\
@@ -282,6 +282,7 @@ typedef std::unordered_map<string, beeswax::TQueryOptionLevel::type>
   QUERY_OPT_FN(test_replan, TEST_REPLAN,\
       TQueryOptionLevel::ADVANCED)\
   QUERY_OPT_FN(lock_max_wait_time_s, LOCK_MAX_WAIT_TIME_S, TQueryOptionLevel::REGULAR)\
+  QUERY_OPT_FN(disable_scan_node_mt, DISABLE_SCAN_NODE_MT, TQueryOptionLevel::ADVANCED)\
   ;
 
 /// Enforce practical limits on some query options to avoid undesired query state.

--- a/common/thrift/ImpalaService.thrift
+++ b/common/thrift/ImpalaService.thrift
@@ -733,6 +733,10 @@ enum TImpalaQueryOptions {
 
   // Maximum wait time on HMS ACID lock in seconds.
   LOCK_MAX_WAIT_TIME_S = 145
+
+  // If true, use HdfsScanNode/KuduScanNode instead of HdfsScanNodeMt/KuduScanNodeMt
+  // in any cases even if mt_dop > 0.
+  DISABLE_SCAN_NODE_MT = 146;
 }
 
 // The summary of a DML statement.

--- a/common/thrift/Query.thrift
+++ b/common/thrift/Query.thrift
@@ -591,6 +591,9 @@ struct TQueryOptions {
 
   // See comment in ImpalaService.thrift
   146: optional i32 lock_max_wait_time_s = 300
+
+  // See comment in ImpalaService.thrift
+  147: optional bool disable_scan_node_mt = false;
 }
 
 // Impala currently has three types of sessions: Beeswax, HiveServer2 and external

--- a/fe/src/main/java/org/apache/impala/planner/HdfsScanNode.java
+++ b/fe/src/main/java/org/apache/impala/planner/HdfsScanNode.java
@@ -1911,6 +1911,16 @@ public class HdfsScanNode extends ScanNode {
             .append(" max-scan-range-rows=")
             .append(PrintUtils.printEstCardinality(maxScanRangeNumRows_))
             .append("\n");
+      String scanNodeType;
+      if (useMtScanNode_) {
+        scanNodeType = "single-threaded";
+      } else {
+        scanNodeType = "multiple-threaded";
+      }
+      output.append(detailPrefix)
+          .append("scan node type: ")
+          .append(scanNodeType)
+          .append("\n");
       if (numScanRangesNoDiskIds_ > 0) {
         output.append(detailPrefix)
           .append(String.format("missing disk ids: "
@@ -1923,7 +1933,6 @@ public class HdfsScanNode extends ScanNode {
       output.append(getMinMaxOriginalConjunctsExplainString(detailPrefix, detailLevel));
       // Groups the dictionary filterable conjuncts by tuple descriptor.
       output.append(getDictionaryConjunctsExplainString(detailPrefix, detailLevel));
-
     }
     if (detailLevel.ordinal() >= TExplainLevel.VERBOSE.ordinal()) {
       // Add file formats after sorting so their order is deterministic in the explain
@@ -2070,7 +2079,7 @@ public class HdfsScanNode extends ScanNode {
     }
 
     // The non-MT scan node requires at least one scanner thread.
-    useMtScanNode_ = queryOptions.mt_dop > 0;
+    useMtScanNode_ = queryOptions.mt_dop > 0 && !queryOptions.disable_scan_node_mt;
     int requiredThreads = useMtScanNode_ ? 0 : 1;
     int maxScannerThreads = computeMaxNumberOfScannerThreads(queryOptions,
         perHostScanRanges);

--- a/fe/src/main/java/org/apache/impala/planner/KuduScanNode.java
+++ b/fe/src/main/java/org/apache/impala/planner/KuduScanNode.java
@@ -412,7 +412,7 @@ public class KuduScanNode extends ScanNode {
         kudu_scanner_thread_max_estimated_bytes;
     long mem_estimate_per_thread = Math.min(getNumMaterializedSlots(desc_) *
         estimated_bytes_per_column_per_thread, max_estimated_bytes_per_thread);
-    useMtScanNode_ = queryOptions.mt_dop > 0;
+    useMtScanNode_ = queryOptions.mt_dop > 0 && !queryOptions.disable_scan_node_mt;
     nodeResourceProfile_ = new ResourceProfileBuilder()
         .setMemEstimateBytes(mem_estimate_per_thread * maxScannerThreads)
         .setThreadReservation(useMtScanNode_ ? 0 : 1).build();
@@ -446,6 +446,16 @@ public class KuduScanNode extends ScanNode {
           result.append(detailPrefix + "runtime filters: ");
           result.append(getRuntimeFilterExplainString(false, detailLevel));
         }
+        String scanNodeType;
+        if (useMtScanNode_) {
+          scanNodeType = "single-threaded";
+        } else {
+          scanNodeType = "multiple-threaded";
+        }
+        result.append(detailPrefix)
+            .append("scan node type: ")
+            .append(scanNodeType)
+            .append("\n");
       }
     }
     return result.toString();

--- a/testdata/workloads/functional-query/queries/QueryTest/disable-scan-node-mt.test
+++ b/testdata/workloads/functional-query/queries/QueryTest/disable-scan-node-mt.test
@@ -1,0 +1,36 @@
+====
+---- QUERY
+# DISABLE_SCAN_NODE_MT=false
+set mt_dop=3;
+set explain_level=3;
+explain select count(*) from alltypes;
+---- RESULTS: VERIFY_IS_SUBSET
+row_regex: .*scan node type: single-threaded
+---- TYPES
+STRING
+====
+---- QUERY
+# DISABLE_SCAN_NODE_MT=true
+set mt_dop=3;
+set disable_scan_node_mt=1;
+set explain_level=3;
+explain select count(*) from alltypes;
+---- RESULTS: VERIFY_IS_SUBSET
+row_regex: .*scan node type: multiple-threaded
+---- TYPES
+STRING
+====
+---- QUERY
+# DISABLE_SCAN_NODE_MT=true, so we can get scanner thread related counters in profile.
+set mt_dop=3;
+set disable_scan_node_mt=1;
+select count(*) from alltypes;
+---- TYPES
+BIGINT
+---- RESULTS
+7300
+---- RUNTIME_PROFILE
+row_regex: .*scan node type: multiple-threaded
+row_regex: .*Query Options \(set by configuration\): .*MT_DOP=3.*DISABLE_SCAN_NODE_MT=1.*
+row_regex: .*AverageScannerThreadConcurrency: .*
+====

--- a/tests/query_test/test_disable_scan_node_mt.py
+++ b/tests/query_test/test_disable_scan_node_mt.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from tests.common.impala_test_suite import ImpalaTestSuite
+from tests.common.skip import (SkipIfEC, SkipIfLocal, SkipIfS3, SkipIfABFS,
+                               SkipIfGCS, SkipIfCOS, SkipIfADLS)
+from tests.common.test_dimensions import create_kudu_dimension
+from tests.common.test_dimensions import create_parquet_dimension
+from tests.common.test_dimensions import create_uncompressed_text_dimension
+
+
+class TestDisableHdfsScanNodeMt(ImpalaTestSuite):
+  """Test disable HdfsScanNodeMt functionality."""
+
+  @classmethod
+  def get_workload(self):
+    return 'functional-query'
+
+  @classmethod
+  def add_test_dimensions(cls):
+    super(TestDisableHdfsScanNodeMt, cls).add_test_dimensions()
+    cls.ImpalaTestMatrix.add_dimension(
+        create_parquet_dimension(cls.get_workload()))
+
+  def test_disable_scan_node_mt(self, vector):
+    self.run_test_case('QueryTest/disable-scan-node-mt', vector)
+
+
+class TestDisableKuduScanNodeMt(ImpalaTestSuite):
+  """Test disable KuduScanNodeMt functionality."""
+
+  @classmethod
+  def get_workload(self):
+    return 'functional-query'
+
+  @classmethod
+  def add_test_dimensions(cls):
+    super(TestDisableKuduScanNodeMt, cls).add_test_dimensions()
+    cls.ImpalaTestMatrix.add_dimension(
+        create_kudu_dimension(cls.get_workload()))
+
+  def test_disable_scan_node_mt(self, vector):
+    self.run_test_case('QueryTest/disable-scan-node-mt', vector)
+
+
+class TestDisableHdfsScanNodeMtWithTextFile(ImpalaTestSuite):
+  """Test disable HdfsScanNodeMt with text file. We may get more instances than files 
+  in some cases, test that we can execute query successfully and get right result."""
+
+  @classmethod
+  def get_workload(self):
+    return 'tpch'
+
+  @classmethod
+  def add_test_dimensions(cls):
+    super(TestDisableHdfsScanNodeMtWithTextFile, cls).add_test_dimensions()
+    cls.ImpalaTestMatrix.add_dimension(
+        create_uncompressed_text_dimension(cls.get_workload()))
+
+  def test_disable_scan_node_mt_with_text_file(self, vector):
+    query = "select count(*) from tpch.lineitem;"
+    vector.get_value('exec_option')['disable_scan_node_mt'] = 1
+    vector.get_value('exec_option')['mt_dop'] = 3
+    results = self.execute_query(query, vector.get_value('exec_option'))
+    assert results.success
+    assert len(results.data) == 1
+    assert int(results.data[0]) == 6001215


### PR DESCRIPTION
This patch add a new query option DISABLE_SCAN_NODE_MT, default to false. If it is set true, the single-threaded scan node (i.e. HdfsScanNodeMt or KuduScanNodeMt) will not be used even if mt_dop > 0. So we can create more scanner threads to achieve faster scanning with mt_dop > 0. Also, the type of scan node is addied to the EXPLAIN output.

Tetting:
  - Added e2e tests to verify the new query option.

Change-Id: I40841eaaeee1756808aa5978cb58517ffd47c040