### PR TITLE
IMPALA-12096: Add process start time and version to backends webui

### DIFF
--- a/be/src/service/impala-http-handler.cc
+++ b/be/src/service/impala-http-handler.cc
@@ -1186,6 +1186,10 @@ void ImpalaHttpHandler::BackendsHandler(const Webserver::WebRequest& req,
     Value executor_groups(JoinStrings(group_names, ", ").c_str(),
         document->GetAllocator());
     backend_obj.AddMember("executor_groups", executor_groups, document->GetAllocator());
+    Value start_time_val(backend.process_start_time().c_str(), document->GetAllocator());
+    backend_obj.AddMember("process_start_time", start_time_val, document->GetAllocator());
+    Value version_val(backend.version().c_str(), document->GetAllocator());
+    backend_obj.AddMember("version", version_val, document->GetAllocator());
     backends_list.PushBack(backend_obj, document->GetAllocator());
   }
   document->AddMember("backends", backends_list, document->GetAllocator());

--- a/be/src/service/impala-server.cc
+++ b/be/src/service/impala-server.cc
@@ -87,6 +87,7 @@
 #include "util/auth-util.h"
 #include "util/bit-util.h"
 #include "util/coding-util.h"
+#include "util/common-metrics.h"
 #include "util/debug-util.h"
 #include "util/error-util.h"
 #include "util/histogram-metric.h"
@@ -2344,6 +2345,13 @@ void ImpalaServer::BuildLocalBackendDescriptorInternal(BackendDescriptorPB* be_d
   be_desc->set_admission_slots(exec_env_->admission_slots());
   be_desc->set_is_quiescing(is_quiescing);
   SetExecutorGroups(FLAGS_executor_groups, be_desc);
+
+  if (CommonMetrics::PROCESS_START_TIME != nullptr) {
+    be_desc->set_process_start_time(CommonMetrics::PROCESS_START_TIME->GetValue());
+  } else {
+    be_desc->set_process_start_time(CurrentTimeString());
+  }
+  be_desc->set_version(GetBuildVersion(/* compact */ true));
 }
 
 ImpalaServer::QueryStateRecord::QueryStateRecord(

--- a/common/protobuf/statestore_service.proto
+++ b/common/protobuf/statestore_service.proto
@@ -76,4 +76,12 @@ message BackendDescriptorPB {
   // The number of admission slots for this backend that can be occupied by running
   // queries.
   optional int64 admission_slots = 12;
+
+  // The process start time of this backend, represented as a date-time string in the
+  // local time zone.
+  optional string process_start_time = 13;
+
+  // The pretty-printed string representation of program version and build version for
+  // this backend.
+  optional string version = 14;
 }

--- a/tests/webserver/test_web_pages.py
+++ b/tests/webserver/test_web_pages.py
@@ -771,6 +771,8 @@ class TestWebPage(ImpalaTestSuite):
     assert not backend_row['is_quiescing']
     assert not backend_row['is_blacklisted']
     assert len(backend_row['admit_mem_limit']) > 0
+    assert len(backend_row['process_start_time']) > 0
+    assert len(backend_row['version']) > 0
 
   def test_download_profile(self):
     """Test download text profile for a query"""

--- a/www/backends.tmpl
+++ b/www/backends.tmpl
@@ -20,13 +20,15 @@ under the License.
 
 <h2>Active backend(s): {{num_active_backends}}</h2>
 
-<table id="backends" class='table table-hover table-bordered'>
+<table id="backends" class='table table-hover table-bordered table-responsive'>
   <thead>
     <tr>
       <th></th>
       <th>Address</th>
       <th>Krpc Address</th>
       <th>Backend Id</th>
+      <th>Version</th>
+      <th>Process Start Time</th>
       <th>Coordinator</th>
       <th>Executor</th>
       <th>Memory Limit for Admission</th>
@@ -45,6 +47,8 @@ under the License.
       <td>{{address}}</td>
       <td>{{krpc_address}}</td>
       <td>{{backend_id}}</td>
+      <td>{{version}}</td>
+      <td>{{process_start_time}}</td>
       <td>{{is_coordinator}}</td>
       <td>{{is_executor}}</td>
       <td>{{admit_mem_limit}}</td>
@@ -62,13 +66,15 @@ under the License.
 {{#num_quiescing_backends}}
 <h2>Quiescing backend(s)<sup><a href='#' data-toggle="tooltip" title="{{> www/quiescing_tooltip.txt }}">[?]</a></sup>: {{num_quiescing_backends}}</h2>
 
-<table id="quiescing_backends" class='table table-hover table-bordered'>
+<table id="quiescing_backends" class='table table-hover table-bordered table-responsive'>
   <thead>
     <tr>
       <th></th>
       <th>Address</th>
       <th>Krpc Address</th>
       <th>Backend Id</th>
+      <th>Version</th>
+      <th>Process Start Time</th>
       <th>Coordinator</th>
       <th>Executor</th>
       <th>Memory Limit for Admission</th>
@@ -87,6 +93,8 @@ under the License.
       <td>{{address}}</td>
       <td>{{krpc_address}}</td>
       <td>{{backend_id}}</td>
+      <td>{{version}}</td>
+      <td>{{process_start_time}}</td>
       <td>{{is_coordinator}}</td>
       <td>{{is_executor}}</td>
       <td>{{admit_mem_limit}}</td>
@@ -105,13 +113,15 @@ under the License.
 {{#num_blacklisted_backends}}
 <h2>Blacklisted backend(s)<sup><a href='#' data-toggle="tooltip" title="{{> www/blacklisted_tooltip.txt }}">[?]</a></sup>: {{num_blacklisted_backends}}</h2>
 
-<table id="blacklisted_backends" class='table table-hover table-bordered'>
+<table id="blacklisted_backends" class='table table-hover table-bordered table-responsive'>
   <thead>
     <tr>
       <th></th>
       <th>Address</th>
       <th>Krpc Address</th>
       <th>Backend Id</th>
+      <th>Version</th>
+      <th>Process Start Time</th>
       <th>Blacklisting Cause</th>
       <th>Time remaining on blacklist</th>
       <th>Coordinator</th>
@@ -132,6 +142,8 @@ under the License.
       <td>{{address}}</td>
       <td>{{krpc_address}}</td>
       <td>{{backend_id}}</td>
+      <td>{{version}}</td>
+      <td>{{process_start_time}}</td>
       <td>{{blacklist_cause}}</td>
       <td>{{blacklist_time_remaining}}</td>
       <td>{{is_coordinator}}</td>


### PR DESCRIPTION
This patch adds process start time and version to the /backends page.

Two more optional elements are added in BackendDescriptorPB and can be broadcast through the statestore topic. This information should be helpful for users checking all backends in a large cluster.

For display, as two more columns are added to the table of backend information, the table is changed to 'table-responsive' to be scrolled horizontally with ease. A sample screenshot is attached to the IMPALA-12096 ticket.

Testing:
- Added cases to test_web_pages.

Change-Id: I5f1f0ba0081986f428840442c247d7dde9e1ba05