### PR TITLE
IMPALA-12312: Planner chooes correct executor group set for planning

### DIFF
--- a/be/src/scheduling/cluster-membership-mgr.h
+++ b/be/src/scheduling/cluster-membership-mgr.h
@@ -289,6 +289,7 @@ class ClusterMembershipMgr {
 /// The frontend uses cluster membership information to determine whether it expects the
 /// scheduler to assign local or remote reads. It also uses the number of executors to
 /// determine the join type (partitioned vs broadcast).
+/// Only non-empty executor group sets will be included in the 'update_req'.
 void PopulateExecutorMembershipRequest(ClusterMembershipMgr::SnapshotPtr& snapshot,
     const std::vector<TExecutorGroupSet>& expected_exec_group_sets,
     TUpdateExecutorMembershipRequest& update_req);


### PR DESCRIPTION
Prior to this patch, planner always selects the default group if there is a default group in an impala cluster. When a client sets a non-default request pool, planner still assumes the query run on the default group and calculates the wrong number of nodes and instances. 

This patch fixes it by including both default and non-default groups in the update message sent from BE to FE, so planner can generate a plan based on correct executor group set info. Besides, if no matched executor group is found, planner falls back to using the default group for planning, which is consistent with BE's behavior in GetExecutorGroupsForQuery.

Testing:
   - Add unit new test cases to ClusterMembershipMgrUnitTest.
   - Add e2e test to verify the new behavior of planner.