### PR TITLE
IMPALA-14714: Fix incorrect results for anti-join with constant ON cl…

### DIFF
--- a/testdata/workloads/functional-planner/queries/PlannerTest/subquery-rewrite.test
+++ b/testdata/workloads/functional-planner/queries/PlannerTest/subquery-rewrite.test
@@ -927,6 +927,7 @@ where not exists (select * from functional.alltypessmall s where s.id < 5)
 PLAN-ROOT SINK
 |
 02:NESTED LOOP JOIN [LEFT ANTI JOIN]
+|  join predicates: TRUE
 |  row-size=89B cardinality=8
 |
 |--01:SCAN HDFS [functional.alltypessmall s]
@@ -950,6 +951,7 @@ where not exists (select 1 from w2)
 PLAN-ROOT SINK
 |
 02:NESTED LOOP JOIN [LEFT ANTI JOIN]
+|  join predicates: TRUE
 |  row-size=89B cardinality=8
 |
 |--01:SCAN HDFS [functional.alltypessmall s]
@@ -973,6 +975,7 @@ where not exists
 PLAN-ROOT SINK
 |
 03:NESTED LOOP JOIN [RIGHT ANTI JOIN]
+|  join predicates: TRUE
 |  row-size=0B cardinality=8
 |
 |--00:SCAN HDFS [functional.alltypestiny t]
@@ -2539,6 +2542,7 @@ select * from functional.alltypessmall where
 PLAN-ROOT SINK
 |
 02:NESTED LOOP JOIN [LEFT ANTI JOIN]
+|  join predicates: TRUE
 |  row-size=89B cardinality=100
 |
 |--01:SCAN HDFS [functional.alltypestiny]
@@ -2602,6 +2606,7 @@ select * from functional.alltypessmall where
 PLAN-ROOT SINK
 |
 03:NESTED LOOP JOIN [LEFT ANTI JOIN]
+|  join predicates: TRUE
 |  row-size=89B cardinality=100
 |
 |--02:AGGREGATE [FINALIZE]
@@ -2693,6 +2698,7 @@ select * from functional.alltypessmall where
 PLAN-ROOT SINK
 |
 03:NESTED LOOP JOIN [LEFT ANTI JOIN]
+|  join predicates: TRUE
 |  row-size=89B cardinality=100
 |
 |--02:SELECT
@@ -4778,6 +4784,7 @@ WHERE -1 NOT IN (SELECT COUNT(id) FROM functional.alltypestiny HAVING false)
 PLAN-ROOT SINK
 |
 02:NESTED LOOP JOIN [LEFT ANTI JOIN]
+|  join predicates: TRUE
 |  row-size=4B cardinality=8
 |
 |--01:EMPTYSET
@@ -4797,6 +4804,7 @@ WHERE -1 NOT IN (SELECT COUNT(id) FROM functional.alltypestiny HAVING count(id) 
 PLAN-ROOT SINK
 |
 03:NESTED LOOP JOIN [LEFT ANTI JOIN]
+|  join predicates: TRUE
 |  row-size=4B cardinality=8
 |
 |--02:AGGREGATE [FINALIZE]

--- a/testdata/workloads/functional-query/queries/QueryTest/semi-joins.test
+++ b/testdata/workloads/functional-query/queries/QueryTest/semi-joins.test
@@ -346,3 +346,190 @@ RIGHT ANTI JOIN SemiJoinTblB b on v.b = b.b
 ---- TYPES
 INT, INT, INT
 ====
+---- QUERY
+# Testing LEFT ANTI JOIN with ON FALSE should return all rows from left table
+# because no rows from right table can match.
+SELECT a.* FROM SemiJoinTblA a LEFT ANTI JOIN SemiJoinTblB b ON false
+---- RESULTS
+1,1,1
+1,1,10
+1,2,10
+1,3,10
+NULL,NULL,30
+2,4,30
+2,NULL,20
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing RIGHT ANTI JOIN with ON FALSE should return all rows from right table
+# because no rows from left table can match.
+SELECT b.* FROM SemiJoinTblA a RIGHT ANTI JOIN SemiJoinTblB b ON false
+---- RESULTS
+1,1,1
+1,1,10
+1,2,5
+1,NULL,10
+2,10,NULL
+3,NULL,NULL
+3,NULL,50
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing LEFT ANTI JOIN with ON TRUE should return empty result set
+# because all rows from right table match.
+SELECT a.* FROM SemiJoinTblA a LEFT ANTI JOIN SemiJoinTblB b ON true
+---- RESULTS
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing RIGHT ANTI JOIN with ON TRUE should return empty result set
+# because all rows from left table match.
+SELECT b.* FROM SemiJoinTblA a RIGHT ANTI JOIN SemiJoinTblB b ON true
+---- RESULTS
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing LEFT ANTI JOIN with constant expression 1=0 (equivalent to FALSE)
+SELECT a.* FROM SemiJoinTblA a LEFT ANTI JOIN SemiJoinTblB b ON 1=0
+---- RESULTS
+1,1,1
+1,1,10
+1,2,10
+1,3,10
+NULL,NULL,30
+2,4,30
+2,NULL,20
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing LEFT ANTI JOIN with constant expression 1=1 (equivalent to TRUE)
+SELECT a.* FROM SemiJoinTblA a LEFT ANTI JOIN SemiJoinTblB b ON 1=1
+---- RESULTS
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing LEFT ANTI JOIN with ON FALSE and WHERE clause
+# Should return rows from left table that satisfy WHERE condition
+SELECT a.* FROM SemiJoinTblA a LEFT ANTI JOIN SemiJoinTblB b ON false
+WHERE a.a = 1
+---- RESULTS
+1,1,1
+1,1,10
+1,2,10
+1,3,10
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing LEFT ANTI JOIN with ON TRUE and WHERE clause
+# Should return empty result (anti-join filters all, then WHERE is applied)
+SELECT a.* FROM SemiJoinTblA a LEFT ANTI JOIN SemiJoinTblB b ON true
+WHERE a.a = 1
+---- RESULTS
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing LEFT SEMI JOIN with ON FALSE should return empty result
+# because no rows from right table can match.
+SELECT a.* FROM SemiJoinTblA a LEFT SEMI JOIN SemiJoinTblB b ON false
+---- RESULTS
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing LEFT SEMI JOIN with ON TRUE should return all rows from left table
+SELECT a.* FROM SemiJoinTblA a LEFT SEMI JOIN SemiJoinTblB b ON true
+---- RESULTS
+1,1,1
+1,1,10
+1,2,10
+1,3,10
+NULL,NULL,30
+2,4,30
+2,NULL,20
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing nested query with LEFT ANTI JOIN ON FALSE
+SELECT * FROM (
+  SELECT a.* FROM SemiJoinTblA a LEFT ANTI JOIN SemiJoinTblB b ON false
+) v WHERE v.a = 2
+---- RESULTS
+2,4,30
+2,NULL,20
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing multiple anti-joins with constant predicates
+SELECT a.* FROM SemiJoinTblA a
+LEFT ANTI JOIN SemiJoinTblB b ON false
+LEFT ANTI JOIN SemiJoinTblB c ON true
+---- RESULTS
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing anti-join with mixed constant and regular predicates (ON FALSE OR a.a = b.a)
+# The OR with FALSE should be optimized away, leaving just a.a = b.a
+# Only rows with NULL in column a are returned because NULL doesn't match anything
+SELECT a.* FROM SemiJoinTblA a LEFT ANTI JOIN SemiJoinTblB b ON (false OR a.a = b.a)
+---- RESULTS
+NULL,NULL,30
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing anti-join with mixed constant and regular predicates (ON TRUE AND a.a = b.a)
+# The AND with TRUE should be optimized away, leaving just a.a = b.a
+# Only rows with NULL in column a are returned because NULL doesn't match anything
+SELECT a.* FROM SemiJoinTblA a LEFT ANTI JOIN SemiJoinTblB b ON (true AND a.a = b.a)
+---- RESULTS
+NULL,NULL,30
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing anti-join with inline view on the left side and ON FALSE
+# The inline view should not be marked as having an empty result set
+SELECT v.* FROM (SELECT * FROM SemiJoinTblA WHERE a = 1) v
+LEFT ANTI JOIN SemiJoinTblB b ON false
+---- RESULTS
+1,1,1
+1,1,10
+1,2,10
+1,3,10
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing nested inline views with anti-join and ON FALSE
+# Verifies that constant predicates don't propagate incorrectly through nested views
+SELECT * FROM (
+  SELECT v.* FROM (SELECT * FROM SemiJoinTblA WHERE a = 2) v
+  LEFT ANTI JOIN SemiJoinTblB b ON false
+) v2 WHERE v2.a = 2
+---- RESULTS
+2,4,30
+2,NULL,20
+---- TYPES
+INT, INT, INT
+====
+---- QUERY
+# Testing anti-join with inline view and mixed predicates
+# Constant FALSE should not be migrated into the inline view
+SELECT v.* FROM (SELECT * FROM SemiJoinTblA WHERE a = 1) v
+LEFT ANTI JOIN SemiJoinTblB b ON (false OR v.a = b.a)
+---- RESULTS
+---- TYPES
+INT, INT, INT
+====
+


### PR DESCRIPTION
…ause predicates

This patch fixes incorrect query results when using LEFT/RIGHT ANTI JOIN with constant predicates in the ON clause (e.g., ON FALSE or ON TRUE).

Previously, constant anti-join predicates were incorrectly handled:
- They were marking the entire query as having an empty result set
- They were being assigned to scan nodes instead of join nodes
- They were being migrated into inline views incorrectly

The fix adds special handling for anti-join conjuncts in Analyzer to:
1. Skip them in markConstantConjunct() to avoid marking query as empty
2. Route constant ON clause predicates to canEvalOnClauseConjunct()
3. Ensure constant anti-join predicates are evaluated at join nodes
4. Prevent migration of anti-join predicates into inline views

Testing:
- Added comprehensive test cases covering ON FALSE, ON TRUE, and mixed predicates for both LEFT and RIGHT ANTI JOIN

Change-Id: I0e0f4a69263bb0ff11f421a1a340dffb904c6842